### PR TITLE
Fix Issue #7 - use val() for inputs, text() for other elements

### DIFF
--- a/jquery.slugify.js
+++ b/jquery.slugify.js
@@ -3,7 +3,8 @@
 	$.fn.slugify = function (source, options) {
 		var $target = this;
 		var $source = $(source);
-
+		var targetIsInput = $target.is('input') || $target.is('textarea');
+		
 		var settings = $.extend({
 			slugFunc: (function (val, originalFunc) { return originalFunc(val); })
 		}, options);
@@ -32,7 +33,11 @@
 
 		var updateSlug = function () {
 			var slug = convertToSlug($(this).val());
-			$target.filter(':not(.slugify-locked)').val(slug).text(slug);
+			if (targetIsInput) {
+				$target.filter(':not(.slugify-locked)').val(slug);
+			} else {
+				$target.filter(':not(.slugify-locked)').text(slug);
+			}
 		};
 
 


### PR DESCRIPTION
IE8 and IE7 were showing "Unexpected call to method or property access"
JavaScript errors due to calling .text() on an input element.
